### PR TITLE
Fix false-positive plugin conflict warnings

### DIFF
--- a/admin/class-plugin-conflict.php
+++ b/admin/class-plugin-conflict.php
@@ -118,7 +118,7 @@ class YMBESEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 		$instance = self::get_instance();
 
 		// Only add plugin as active plugin if $plugin isn't false.
-		if ( $plugin ) {
+		if ( $plugin && is_string( $plugin ) ) {
 			// Because it's just activated.
 			$instance->add_active_plugin( $instance->find_plugin_category( $plugin ), $plugin );
 		}


### PR DESCRIPTION
See: https://github.com/Yoast/wordpress-seo/commit/4188c64877bc3b86a4e131775182dc703f75197c